### PR TITLE
[J133] SeatSelectionArea와 관련된 리팩토링 진행

### DIFF
--- a/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
@@ -35,16 +35,15 @@ export default function SeatSelectionArea() {
       return seat;
     })
 
-    componentSeats.forEach(function (x:any) {
-        ctx.current.fillStyle = x.color;
-        ctx.current.fillRect(x.point.x, x.point.y, 10, 10);
+    componentSeats.forEach((seat:SeatInfo) => {
+        ctx.current.fillStyle = seat.color;
+        ctx.current.fillRect(seat.point.x, seat.point.y, 10, 10);
       });
   }
 
   const clickEvent = (e:any) => {
     e.stopPropagation();
-
-    componentSeats.forEach((seat:any) => {
+    componentSeats.forEach((seat:SeatInfo) => {
         if (
           e.offsetX > seat.point.x &&
           e.offsetX < seat.point.x + 10 &&

--- a/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
@@ -7,13 +7,9 @@ import useSelectSeat from '../../../hooks/useSelectSeat';
 import useCancelSeat from '../../../hooks/useCancelSeat';
 import useSeats from '../../../hooks/useSeats';
 import {socket} from "../../../socket"
-
-
-const sold = '#D8D8D8';
-const unsold = '#01DF3A';
-const clicked = '#FA58F4'
-const cancelled = '#000000';
-const myClicked = '#6495ED';
+import {SEAT_STATUS} from "../../../constants/seatStatus";
+import {SEAT_COLOR} from "../../../styles/seatColor"
+import {SeatInfo}from "../../../types/seatInfo"
 
 const Box = styled(Toolbar)({
   minHeight: "22rem",
@@ -21,55 +17,50 @@ const Box = styled(Toolbar)({
   padding: "0 1rem",
 });
 
-let mySeat:Array<String> = [];
-let data:any;
+let componentSelectedSeats:{[index: string]:SeatInfo} = {};
+let componentSeats:SeatInfo[] = [];
 
 export default function SeatSelectionArea() {
-  let canvasRef: any = useRef();
-  let canvas: any;
-  let ctx:any;
+  const canvasRef:any = useRef(null);
+  const ctx:any = useRef(null);
   const {serverSeats} = useContext(SeatContext);
   const seats = useSeats().selectedSeat;
   const selectSeat = useSelectSeat();
   const cancelSeat = useCancelSeat();
 
   const draw = () => {
-      if (mySeat.length) {
-        data = data.map((seat:any) => {
-        for (let i = 0; i < mySeat.length; i++) {
-            if (mySeat[i] === seat.id)  {
-                seat.color = myClicked;
-                return seat;
-            }
-        }
-        return seat;
+
+    componentSeats = componentSeats.map((seat:SeatInfo) => {
+        if (componentSelectedSeats[seat.id]) seat.color = SEAT_COLOR.MYSEAT;
+      return seat;
     })
-  }
-      data.forEach(function (x:any) {
-          ctx.fillStyle = x.color;
-          ctx.fillRect(x.point.x, x.point.y, 10, 10);
+
+    componentSeats.forEach(function (x:any) {
+        ctx.current.fillStyle = x.color;
+        ctx.current.fillRect(x.point.x, x.point.y, 10, 10);
       });
   }
 
   const clickEvent = (e:any) => {
-      e.stopPropagation();
-      data.forEach((seat:any) => {
+    e.stopPropagation();
+
+    componentSeats.forEach((seat:any) => {
         if (
           e.offsetX > seat.point.x &&
           e.offsetX < seat.point.x + 10 &&
           e.offsetY > seat.point.y &&
           e.offsetY < seat.point.y + 10
         ) {
-          if (seat.status === 'unsold' ) {
-            seat.status = 'clicked';
-            seat.color = clicked;
+          if (seat.status === SEAT_STATUS.UNSOLD ) {
+            seat.status = SEAT_STATUS.CLICKED;
+            seat.color = SEAT_COLOR.CLICKED;
             selectSeat(seat);
             socket.emit("clickSeat", "A", seat.id, seat);
             return seat;
           }
-          else if (seat.status === 'clicked' && mySeat && mySeat.some((mySeatId: any) => mySeatId === seat.id)) {
-            seat.status = 'unsold';
-            seat.color = unsold;
+          else if (seat.status === SEAT_STATUS.CLICKED && componentSelectedSeats[seat.id]) {
+            seat.status = SEAT_STATUS.UNSOLD;
+            seat.color = SEAT_COLOR.UNSOLD;
             cancelSeat(seat.id);
             socket.emit("clickSeat", "A", seat.id, seat);
             return seat;
@@ -79,24 +70,19 @@ export default function SeatSelectionArea() {
     };
   
   useEffect(() => {
-    canvas = canvasRef.current;
-    ctx = canvas.getContext("2d");
+    const canvas = canvasRef.current;
+    ctx.current = canvas.getContext("2d");
     canvas.addEventListener('click', clickEvent);
     socket.emit("joinRoom", "A");
   }, [])
 
   useEffect(()=> {
-  if (seats.length) mySeat = seats.map((seat)=>`${seat.id}`);
-  else mySeat = [];
+    if (seats.length) componentSelectedSeats = seats.reduce((map:{[index: string]:SeatInfo}, seat)=>{ map[seat.id] = seat; return map},{});
+    else componentSelectedSeats = {};
   }, [seats]);
 
   useEffect(()=> {
-    if (!ctx) {
-      canvas = canvasRef.current;
-      ctx = canvas.getContext("2d");
-    }
-
-    data = [...serverSeats];
+    componentSeats = [...serverSeats];
     draw();
   }, [serverSeats])
 

--- a/client/src/constants/seatStatus.ts
+++ b/client/src/constants/seatStatus.ts
@@ -1,0 +1,6 @@
+export enum SEAT_STATUS {
+    CLICKED= "clicked",
+    UNSOLD = "unsold",
+    SOLD = "sold",
+    CANCELLED = "cancelled"
+}

--- a/client/src/modules/seats.ts
+++ b/client/src/modules/seats.ts
@@ -1,17 +1,9 @@
+import {SeatInfo}from "../types/seatInfo"
 const INCREASE_SEAT = "seats/INCREASE_SEAT" as const;
 const DECREASE_SEAT = "seats/DECREASE_SEAT" as const;
 const SELECT_SEAT = "seats/SELECT_SEAT" as const;
 const CANCEL_SEAT = "seats/CANCEL_SEAT" as const;
-const INIT_SERVER_SEAT = "seats/INIT_SERVER_SEAT" as const;
 // TODO: 해당 회차 공연 정보 가져오는 action추가?
-interface SeatInfo {
-  id: string;
-  color: string;
-  name: string;
-  point: object;
-  status: string;
-}
-
 interface SeatCount {
   name: string;
   color: string;

--- a/client/src/styles/seatColor.ts
+++ b/client/src/styles/seatColor.ts
@@ -1,0 +1,7 @@
+export enum SEAT_COLOR {
+    SOLD = '#D8D8D8',
+    UNSOLD = '#01DF3A',
+    CLICKED = '#FA58F4',
+    CANCEELED = '#000000',
+    MYSEAT = '#6495ED',
+}

--- a/client/src/types/seatInfo.ts
+++ b/client/src/types/seatInfo.ts
@@ -2,6 +2,6 @@ export interface SeatInfo {
     id: string;
     color: string;
     name: string;
-    point: object;
+    point: {x:number, y:number};
     status: string;
 }


### PR DESCRIPTION
- 컴포넌트의 선택된 좌석을 배열에서 Map으로 변경하여 관리하도록 변경
- canvas와 관련된 변수인 ctx와 canvasRef 변수를 useRef를 활용하여 렌더링 되더라도 다시 할당되지 않도록 변경
- 각 종 인자 및 변수들에 조금더 구체적인 타입을 지정하도록 변경
- canvasRef, ctx 와 클릭이벤트에 대한 타입을 아직 지정하지 못함