### PR TITLE
[J106] 잔여석 소켓과 graphql서버와 연결

### DIFF
--- a/api-server/db/mongo.ts
+++ b/api-server/db/mongo.ts
@@ -4,9 +4,13 @@ const connectMongoDB = () => {
   const mongoHost = (process.env.NODE_ENV === "production"
     ? process.env.MONGO_PRODUCTION_HOST
     : process.env.MONGO_LOCAL_HOST) as string;
-  mongoose.connect(mongoHost, { useUnifiedTopology: true, useNewUrlParser: true }, (err: any) => {
-    console.log(err);
-  });
+  mongoose.connect(
+    mongoHost,
+    { dbName: "project7", useUnifiedTopology: true, useNewUrlParser: true },
+    (err: any) => {
+      console.log(err);
+    },
+  );
 
   const { connection } = mongoose;
   connection.on("error", console.error.bind(console, "connection error:"));

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -10,8 +10,6 @@ import { EmptySeatsCount } from "../../common";
 import { useHistory } from "react-router-dom";
 import { ko } from "date-fns/locale";
 
-const date = new Date();
-
 const disabledDates = [
   new Date("2020-12-01"),
   new Date("2020-12-04"),
@@ -119,7 +117,7 @@ const SelectSeatBtn = styled(Button)((props) => ({
 
 const tileDisabled = ({ date, view }) => {
   if (view === "month") {
-    return disabledDates.find(dDate => isSameDay(dDate, date));
+    return disabledDates.find((dDate) => isSameDay(dDate, date));
   }
 };
 
@@ -149,7 +147,6 @@ export default function CalendarPicker({ setTimeDetail }) {
             concert.date === value.getDate()
         )
       );
-      console.log(value.getMonth());
     }
     setValue(value);
   };

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -204,7 +204,7 @@ export default function CalendarPicker({ setTimeDetail }) {
                 >
                   {format(
                     new Date(0, 0, 0, concert.hour, concert.minute),
-                    "a H:mm",
+                    "a h:mm",
                     { locale: ko }
                   )}
                 </span>

--- a/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
@@ -1,15 +1,15 @@
-import {useContext} from "react";
+import { useContext } from "react";
 import { styled } from "@material-ui/core/styles";
 import { Toolbar } from "@material-ui/core";
-import React, {useRef, useEffect} from 'react'
-import {SeatContext} from "../../../stores/SeatStore";
-import useSelectSeat from '../../../hooks/useSelectSeat';
-import useCancelSeat from '../../../hooks/useCancelSeat';
-import useSeats from '../../../hooks/useSeats';
-import {socket} from "../../../socket"
-import {SEAT_STATUS} from "../../../constants/seatStatus";
-import {SEAT_COLOR} from "../../../styles/seatColor"
-import {SeatInfo}from "../../../types/seatInfo"
+import React, { useRef, useEffect } from "react";
+import { SeatContext } from "../../../stores/SeatStore";
+import useSelectSeat from "../../../hooks/useSelectSeat";
+import useCancelSeat from "../../../hooks/useCancelSeat";
+import useSeats from "../../../hooks/useSeats";
+import { socket } from "../../../socket";
+import { SEAT_STATUS } from "../../../constants/seatStatus";
+import { SEAT_COLOR } from "../../../styles/seatColor";
+import { SeatInfo } from "../../../types/seatInfo";
 
 const Box = styled(Toolbar)({
   minHeight: "22rem",
@@ -17,77 +17,87 @@ const Box = styled(Toolbar)({
   padding: "0 1rem",
 });
 
-let componentSelectedSeats:{[index: string]:SeatInfo} = {};
-let componentSeats:SeatInfo[] = [];
+let componentSelectedSeats: { [index: string]: SeatInfo } = {};
+let componentSeats: SeatInfo[] = [];
 
 export default function SeatSelectionArea() {
-  const canvasRef:any = useRef(null);
-  const ctx:any = useRef(null);
-  const {serverSeats} = useContext(SeatContext);
+  const canvasRef: any = useRef(null);
+  const ctx: any = useRef(null);
+  const { serverSeats } = useContext(SeatContext);
   const seats = useSeats().selectedSeat;
   const selectSeat = useSelectSeat();
   const cancelSeat = useCancelSeat();
 
   const draw = () => {
-
-    componentSeats = componentSeats.map((seat:SeatInfo) => {
-        if (componentSelectedSeats[seat.id]) seat.color = SEAT_COLOR.MYSEAT;
+    componentSeats = componentSeats.map((seat: SeatInfo) => {
+      if (componentSelectedSeats[seat.id]) seat.color = SEAT_COLOR.MYSEAT;
       return seat;
-    })
+    });
 
-    componentSeats.forEach((seat:SeatInfo) => {
-        ctx.current.fillStyle = seat.color;
-        ctx.current.fillRect(seat.point.x, seat.point.y, 10, 10);
-      });
-  }
+    componentSeats.forEach((seat: SeatInfo) => {
+      ctx.current.fillStyle = seat.color;
+      ctx.current.fillRect(seat.point.x, seat.point.y, 10, 10);
+    });
+  };
 
-  const clickEvent = (e:any) => {
+  const clickEvent = (e: any) => {
     e.stopPropagation();
-    componentSeats.forEach((seat:SeatInfo) => {
-        if (
-          e.offsetX > seat.point.x &&
-          e.offsetX < seat.point.x + 10 &&
-          e.offsetY > seat.point.y &&
-          e.offsetY < seat.point.y + 10
+    componentSeats.forEach((seat: SeatInfo) => {
+      if (
+        e.offsetX > seat.point.x &&
+        e.offsetX < seat.point.x + 10 &&
+        e.offsetY > seat.point.y &&
+        e.offsetY < seat.point.y + 10
+      ) {
+        if (seat.status === SEAT_STATUS.UNSOLD) {
+          seat.status = SEAT_STATUS.CLICKED;
+          seat.color = SEAT_COLOR.CLICKED;
+          selectSeat(seat);
+          socket.emit("clickSeat", "A", seat.id, seat);
+          return seat;
+        } else if (
+          seat.status === SEAT_STATUS.CLICKED &&
+          componentSelectedSeats[seat.id]
         ) {
-          if (seat.status === SEAT_STATUS.UNSOLD ) {
-            seat.status = SEAT_STATUS.CLICKED;
-            seat.color = SEAT_COLOR.CLICKED;
-            selectSeat(seat);
-            socket.emit("clickSeat", "A", seat.id, seat);
-            return seat;
-          }
-          else if (seat.status === SEAT_STATUS.CLICKED && componentSelectedSeats[seat.id]) {
-            seat.status = SEAT_STATUS.UNSOLD;
-            seat.color = SEAT_COLOR.UNSOLD;
-            cancelSeat(seat.id);
-            socket.emit("clickSeat", "A", seat.id, seat);
-            return seat;
-          }
+          seat.status = SEAT_STATUS.UNSOLD;
+          seat.color = SEAT_COLOR.UNSOLD;
+          cancelSeat(seat.id);
+          socket.emit("clickSeat", "A", seat.id, seat);
+          return seat;
         }
-      });
-    };
-  
+      }
+    });
+  };
+
   useEffect(() => {
     const canvas = canvasRef.current;
     ctx.current = canvas.getContext("2d");
-    canvas.addEventListener('click', clickEvent);
+    canvas.addEventListener("click", clickEvent);
     socket.emit("joinRoom", "A");
-  }, [])
+  }, []);
 
-  useEffect(()=> {
-    if (seats.length) componentSelectedSeats = seats.reduce((map:{[index: string]:SeatInfo}, seat)=>{ map[seat.id] = seat; return map},{});
+  useEffect(() => {
+    if (seats.length)
+      componentSelectedSeats = seats.reduce(
+        (map: { [index: string]: SeatInfo }, seat) => {
+          map[seat.id] = seat;
+          return map;
+        },
+        {}
+      );
     else componentSelectedSeats = {};
   }, [seats]);
 
-  useEffect(()=> {
-    componentSeats = [...serverSeats];
+  useEffect(() => {
+    componentSeats = [...serverSeats.seats];
     draw();
-  }, [serverSeats])
+  }, [serverSeats.seats]);
 
   return (
     <>
-      <Box><canvas ref={canvasRef} /></Box>
+      <Box>
+        <canvas ref={canvasRef} />
+      </Box>
     </>
   );
 }

--- a/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
+++ b/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
@@ -1,9 +1,27 @@
-import React from "react";
+import React, { useEffect, useContext, useState } from "react";
 import { Box } from "@material-ui/core";
 import { makeStyles, styled } from "@material-ui/core/styles";
 import { colors } from "../../../styles/variables";
 import useSeats from "../../../hooks/useSeats";
+import { SeatContext } from "../../../stores/SeatStore";
+import { EmptySeatCount } from "../../../types/seatInfo";
+import { socket } from "../../../socket";
+import { useQuery, gql } from "@apollo/client";
 
+const GET_ITEMS = gql`
+  query {
+    itemDetail(itemId: "5fc7834bd703ca7366b38959") {
+      prices {
+        class
+        price
+      }
+      classes {
+        class
+        color
+      }
+    }
+  }
+`;
 interface styleProps {
   color: string;
 }
@@ -60,21 +78,37 @@ const Badge = styled(Box)((props: styleProps) => ({
 export default function EmptySeatsCount() {
   const classes = useStyles();
   const seats = useSeats();
+  const [seatsCount, setSeatsCount] = useState<EmptySeatCount[]>([]);
+  const { serverSeats } = useContext(SeatContext);
+
+  const { loading, error, data } = useQuery(GET_ITEMS);
+  console.log(loading, error, data);
+
+  useEffect(() => {
+    socket.emit("joinRoom", "A");
+    setSeatsCount([...serverSeats.counts]);
+  }, []);
+
+  useEffect(() => {
+    setSeatsCount([...serverSeats.counts]);
+    console.log(seatsCount);
+  }, [serverSeats.counts]);
+
   return (
     <>
       <Box className={classes.info}>
         <table className={classes.table}>
           <tbody>
-            {seats.seatCount.map((element, idx) => {
+            {seatsCount.map((element, idx) => {
               return (
                 <tr key={idx} className={classes.item}>
                   <td className={classes.title}>
-                    <Badge component="span" color={element.color}></Badge>
-                    <span>{element.name}</span>
+                    <Badge component="span" color="#1200D3"></Badge>
+                    <span>{element.class}</span>
                   </td>
                   <td className={classes.seatCount}>잔여 {element.count}석</td>
                   <td className={classes.price}>
-                    {new Intl.NumberFormat("ko-KR").format(element.price)}원
+                    {new Intl.NumberFormat("ko-KR").format(100000)}원
                   </td>
                 </tr>
               );

--- a/client/src/reducers/seatReducer.ts
+++ b/client/src/reducers/seatReducer.ts
@@ -1,16 +1,18 @@
-import {SeatInfo} from "../types/seatInfo"
+import { SeatInfo, EmptySeatCount } from "../types/seatInfo";
 
 interface ReducerData {
-    type: string,
-    payload: SeatInfo[]
+  type: string;
+  payload: { seats: SeatInfo[]; counts: EmptySeatCount[] };
 }
 
-export const seatReducer = (serverSeats:any, data:ReducerData) => {
-    switch(data.type) {
-        case "SET_DATA" : 
-            return [...data.payload];
-        default :
-            return serverSeats;
-
-    }
-}
+export const seatReducer = (serverSeats: any, data: ReducerData) => {
+  switch (data.type) {
+    case "SET_DATA":
+      return {
+        seats: [...data.payload.seats],
+        counts: [...data.payload.counts],
+      };
+    default:
+      return serverSeats;
+  }
+};

--- a/client/src/service/index.ts
+++ b/client/src/service/index.ts
@@ -1,7 +1,7 @@
 import { ApolloClient, InMemoryCache } from "@apollo/client";
 
 const URI = process.env.REACT_APP_LOCAL_API_SERVER_URI;
-console.log(URI);
+
 const client = new ApolloClient({
   uri: URI,
   cache: new InMemoryCache(),

--- a/client/src/stores/SeatStore.tsx
+++ b/client/src/stores/SeatStore.tsx
@@ -1,20 +1,28 @@
 import React, { useReducer, useEffect } from "react";
 import { seatReducer } from "../reducers/seatReducer";
 import { socket } from "../socket";
+import { SeatInfo, EmptySeatCount } from "../types/seatInfo";
 
 export const SeatContext = React.createContext<any>(null);
+export const CountContext = React.createContext<any>(null);
 
 export function SeatStore({ children }: { children: React.ReactNode }) {
-  const [serverSeats, dispatch] = useReducer(seatReducer, []);
+  const [serverSeats, dispatch] = useReducer(seatReducer, {
+    seats: [],
+    counts: [],
+  });
 
   const setServerSeats = (seats: any) => {
     dispatch({ type: "SET_DATA", payload: seats });
   };
 
   useEffect(() => {
-    socket.on("receiveData", (seatData: any) => {
-      setServerSeats(seatData.seats);
-    });
+    socket.on(
+      "receiveData",
+      (seatData: { seats: SeatInfo[]; counts: EmptySeatCount[] }) => {
+        setServerSeats(seatData);
+      }
+    );
   }, []);
 
   return (

--- a/client/src/types/seatInfo.ts
+++ b/client/src/types/seatInfo.ts
@@ -1,7 +1,12 @@
 export interface SeatInfo {
-    id: string;
-    color: string;
-    name: string;
-    point: {x:number, y:number};
-    status: string;
+  id: string;
+  color: string;
+  name: string;
+  point: { x: number; y: number };
+  status: string;
+}
+
+export interface EmptySeatCount {
+  class: string;
+  count: number;
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2,6 +2,25 @@
 # yarn lockfile v1
 
 
+"@apollo/client@3.2.9":
+  version "3.2.9"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.9.tgz#a24a7792519adb3af8a74a60d9e83732238d0afd"
+  integrity sha512-AUvYITKhJNfRNU/Cf8t/N628ADdVah1+l9Qtjd09IwScRfDGvbBTkHMAgcb6hl7vuBVqGwQRq6fPKzHgWRlisg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.0.0"
+    "@types/zen-observable" "^0.8.0"
+    "@wry/context" "^0.5.2"
+    "@wry/equality" "^0.2.0"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.11.0"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.13.0"
+    prop-types "^15.7.2"
+    symbol-observable "^2.0.0"
+    ts-invariant "^0.5.0"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@babel/code-frame@7.10.4", "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.5.5":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
@@ -1078,6 +1097,11 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
+"@graphql-typed-document-node/core@^3.0.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.0.tgz#0eee6373e11418bfe0b5638f654df7a4ca6a3950"
+  integrity sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1935,6 +1959,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/zen-observable@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.1.tgz#5668c0bce55a91f2b9566b1d8a4c0a8dbbc79764"
+  integrity sha512-wmk0xQI6Yy7Fs/il4EpOcflG4uonUpYGqvZARESLc2oy4u69fkatFLbJOeW4Q6awO15P4rduAe6xkwHevpXcUQ==
+
 "@typescript-eslint/eslint-plugin@^4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.5.0.tgz#4ff9c1d8535ae832e239f0ef6d7210592d9b0b07"
@@ -2191,6 +2220,20 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@wojtekmaj/date-utils/-/date-utils-1.0.3.tgz#2dcfd92881425c5923e429c2aec86fb3609032a1"
   integrity sha512-1VPkkTBk07gMR1fjpBtse4G+oJqpmE+0gUFB0dg3VIL7qJmUVaBoD/vlzMm/jNeOPfvlmerl1lpnsZyBUFIRuw==
+
+"@wry/context@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.2.tgz#f2a5d5ab9227343aa74c81e06533c1ef84598ec7"
+  integrity sha512-B/JLuRZ/vbEKHRUiGj6xiMojST1kHhu4WcreLfNN7q9DqQFrb97cWgf/kiYsPSUCAMVN0HzfFc8XjJdzgZzfjw==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.2.0.tgz#a312d1b6a682d0909904c2bcd355b02303104fb7"
+  integrity sha512-Y4d+WH6hs+KZJUC8YKLYGarjGekBrhslDbf/R20oV+AakHPINSitHfDRQz3EGcEWc1luXYNUvMhawWtZVWNGvQ==
+  dependencies:
+    tslib "^1.9.3"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5504,6 +5547,16 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
+graphql@15.4.0:
+  version "15.4.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
+  integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -8054,6 +8107,13 @@ opn@^5.5.0:
   integrity sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==
   dependencies:
     is-wsl "^1.1.0"
+
+optimism@^0.13.0:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.1.tgz#df2e6102c973f870d6071712fffe4866bb240384"
+  integrity sha512-16RRVYZe8ODcUqpabpY7Gb91vCAbdhn8FHjlUb2Hqnjjow1j8Z1dlppds+yAsLbreNTVylLC+tNX6DuC2vt3Kw==
+  dependencies:
+    "@wry/context" "^0.5.2"
 
 optimize-css-assets-webpack-plugin@5.0.4:
   version "5.0.4"
@@ -10925,6 +10985,11 @@ symbol-observable@1.2.0, symbol-observable@^1.2.0:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-observable@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
@@ -11174,6 +11239,13 @@ tryer@^1.0.1:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
+ts-invariant@^0.5.0:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.5.1.tgz#4171fdb85f72a40381c147afd97c12154ada2abc"
+  integrity sha512-k3UpDNrBZpqJFnAAkAHNmSHtNuCxcU6xLiziPgalHRKZHme6T6jnKC8CcXDmk1zbHLQM8pc+rNC1Q6FvXMAl+g==
+  dependencies:
+    tslib "^1.9.3"
+
 ts-pnp@1.2.0, ts-pnp@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
@@ -11189,7 +11261,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
@@ -12100,3 +12172,8 @@ yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
   integrity sha1-AI4G2AlDIMNy28L47XagymyKxBk=
+
+zen-observable@^0.8.14:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
## 구현 내용
- [x] 잔여석을 전역스토어에서 관리하도록 변경
- [x] 회차선택 페이지의 잔여석 정보 소켓에서 잔여석 count 받아와서 실시간으로 보여주도록 변경
- [x] 잔여석의 색, 클래스, 가격정보 graphql 로 받아와서 보여주도록 변경
## 수정해야 할 것
- [ ] graphql에서 받아온 잔여석 정보를 class를 key로 map만들어서 보여주기