### PR TITLE
[J106] 변경된 소켓 이벤트로 수정, 좌석선택페이지 잔여석 소켓 연결

### DIFF
--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -9,6 +9,7 @@ import DateRangeIcon from "@material-ui/icons/DateRange";
 import { EmptySeatsCount } from "../../common";
 import { useHistory } from "react-router-dom";
 import { ko } from "date-fns/locale";
+import { socket } from "../../../socket";
 
 const disabledDates = [
   new Date("2020-12-01"),
@@ -154,6 +155,8 @@ export default function CalendarPicker({ setTimeDetail }) {
   const handleOnClick = (e) => {
     setSelectedConcertId(e.target.id);
     console.log(selectedConcertId);
+    //socket.emit("leaveCountRoom", scheduleID);
+    socket.emit("joinCountRoom", "A");
   };
 
   const handleOnClickBtn = () => {

--- a/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
@@ -141,7 +141,7 @@ export default function SeatInfoArea() {
   const seats = useSeats();
   const cancelSeat = useCancelSeat();
   const history = useHistory();
-  const [seatsCount, setSeatsCount] = useState<EmptySeatCount[]>([]);
+  const [seatsCount, setSeatsCount] = useState<any>({});
   const { serverSeats } = useContext(SeatContext);
   const GET_ITEMS = gql`
     query {
@@ -159,7 +159,7 @@ export default function SeatInfoArea() {
     seat.status = "unsold";
     seat.color = unsold;
     cancelSeat(seat.id);
-    socket.emit("clickSeat", "A", seat.id, seat);
+    socket.emit("clickSeat", "A", seat);
   };
 
   const handleClickPre = () => {
@@ -198,14 +198,19 @@ export default function SeatInfoArea() {
         <Box className={classes.seatInfo}>
           <Box className={classes.info}>
             <List dense={true}>
-              {seats.seatCount.map((element, idx) => {
+              {Object.keys(seatsCount).map((element, idx) => {
                 return (
                   <ListItem key={idx} className={classes.item}>
                     <Box className={classes.title}>
-                      <Badge component="span" color={element.color}></Badge>
-                      <span>{element.name}</span>
+                      <Badge
+                        component="span"
+                        color={data.itemDetail.classes[idx].color}
+                      ></Badge>
+                      <span>{element}</span>
                     </Box>
-                    <Box className={classes.seatCount}>{element.count}석</Box>
+                    <Box className={classes.seatCount}>
+                      {seatsCount[element]}석
+                    </Box>
                   </ListItem>
                 );
               })}

--- a/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
@@ -174,11 +174,11 @@ export default function SeatInfoArea() {
   };
 
   useEffect(() => {
-    socket.emit("joinRoom", "A");
-    setSeatsCount([...serverSeats.counts]);
+    socket.emit("joinCountRoom", "A");
+    setSeatsCount({ ...serverSeats.counts });
   }, []);
   useEffect(() => {
-    setSeatsCount([...serverSeats.counts]);
+    setSeatsCount({ ...serverSeats.counts });
   }, [serverSeats.counts]);
   if (loading) return <h1>"Loading..."</h1>;
   if (error) return <h1>`Error! ${error.message}`</h1>;

--- a/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
@@ -53,7 +53,8 @@ export default function SeatSelectionArea() {
           seat.status = SEAT_STATUS.CLICKED;
           seat.color = SEAT_COLOR.CLICKED;
           selectSeat(seat);
-          socket.emit("clickSeat", "A", seat.id, seat);
+          socket.emit("clickSeat", "A", seat);
+          console.log(seat);
           return seat;
         } else if (
           seat.status === SEAT_STATUS.CLICKED &&
@@ -62,7 +63,8 @@ export default function SeatSelectionArea() {
           seat.status = SEAT_STATUS.UNSOLD;
           seat.color = SEAT_COLOR.UNSOLD;
           cancelSeat(seat.id);
-          socket.emit("clickSeat", "A", seat.id, seat);
+          socket.emit("clickSeat", "A", seat);
+          console.log(seat);
           return seat;
         }
       }
@@ -73,7 +75,10 @@ export default function SeatSelectionArea() {
     const canvas = canvasRef.current;
     ctx.current = canvas.getContext("2d");
     canvas.addEventListener("click", clickEvent);
-    socket.emit("joinRoom", "A");
+    socket.emit("joinBookingRoom", "A");
+    return () => {
+      socket.emit("leaveBookingRoom", "A");
+    };
   }, []);
 
   useEffect(() => {

--- a/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
+++ b/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
@@ -82,7 +82,7 @@ const Badge = styled(Box)((props: styleProps) => ({
 
 export default function EmptySeatsCount() {
   const classes = useStyles();
-  const [seatsCount, setSeatsCount] = useState<EmptySeatCount[]>([]);
+  const [seatsCount, setSeatsCount] = useState<any>({});
   const { serverSeats } = useContext(SeatContext);
   let seatInfo: SeatInfo[] = [];
   // const [seatInfo, setSeatInfo] = useState<{ color: string; price: number }[]>(
@@ -107,12 +107,12 @@ export default function EmptySeatsCount() {
   const { loading, error, data } = useQuery(GET_ITEMS);
 
   useEffect(() => {
-    socket.emit("joinRoom", "A");
-    setSeatsCount([...serverSeats.counts]);
+    socket.emit("joinCountRoom", "A");
+    setSeatsCount({ ...serverSeats.counts });
   }, []);
 
   useEffect(() => {
-    setSeatsCount([...serverSeats.counts]);
+    setSeatsCount({ ...serverSeats.counts });
   }, [serverSeats.counts]);
 
   if (loading) return "Loading...";
@@ -131,14 +131,16 @@ export default function EmptySeatsCount() {
       <Box className={classes.info}>
         <table className={classes.table}>
           <tbody>
-            {seatsCount.map((element, idx) => {
+            {Object.keys(seatsCount).map((element, idx) => {
               return (
                 <tr key={idx} className={classes.item}>
                   <td className={classes.title}>
                     <Badge component="span" color={seatInfo[idx].color}></Badge>
-                    <span>{element.class}</span>
+                    <span>{element}</span>
                   </td>
-                  <td className={classes.seatCount}>잔여 {element.count}석</td>
+                  <td className={classes.seatCount}>
+                    잔여 {seatsCount[element]}석
+                  </td>
                   <td className={classes.price}>
                     {new Intl.NumberFormat("ko-KR").format(seatInfo[idx].price)}
                     원

--- a/client/src/reducers/seatReducer.ts
+++ b/client/src/reducers/seatReducer.ts
@@ -10,7 +10,7 @@ export const seatReducer = (serverSeats: any, data: ReducerData) => {
     case "SET_DATA":
       return {
         seats: [...data.payload.seats],
-        counts: [...data.payload.counts],
+        counts: { ...data.payload.counts },
       };
     default:
       return serverSeats;

--- a/client/src/reducers/seatReducer.ts
+++ b/client/src/reducers/seatReducer.ts
@@ -2,7 +2,7 @@ import { SeatInfo, EmptySeatCount } from "../types/seatInfo";
 
 interface ReducerData {
   type: string;
-  payload: { seats: SeatInfo[]; counts: EmptySeatCount[] };
+  payload: { seats: SeatInfo[]; counts: Object };
 }
 
 export const seatReducer = (serverSeats: any, data: ReducerData) => {

--- a/client/src/stores/SeatStore.tsx
+++ b/client/src/stores/SeatStore.tsx
@@ -4,7 +4,6 @@ import { socket } from "../socket";
 import { SeatInfo, EmptySeatCount } from "../types/seatInfo";
 
 export const SeatContext = React.createContext<any>(null);
-export const CountContext = React.createContext<any>(null);
 
 export function SeatStore({ children }: { children: React.ReactNode }) {
   const [serverSeats, dispatch] = useReducer(seatReducer, {
@@ -17,17 +16,15 @@ export function SeatStore({ children }: { children: React.ReactNode }) {
   };
 
   useEffect(() => {
-    socket.on(
-      "receiveSeat",
-      (seatData: { seats: SeatInfo[]; counts: EmptySeatCount[] }) => {
-        console.log(seatData);
-        setServerSeats(seatData);
-      }
-    );
+    let seats: any[] = [];
+    let counts = {};
+    socket.on("receiveSeat", (seatData: { seats: SeatInfo[] }) => {
+      seats = [...seatData.seats];
+      setServerSeats({ counts: { ...counts }, seats: seatData.seats });
+    });
     socket.on("receiveCount", (seatData: { counts: Object[] }) => {
-      console.log(seatData);
-      console.log({ ...serverSeats, counts: seatData.counts[0] });
-      setServerSeats({ ...serverSeats, counts: seatData.counts[0] });
+      counts = { ...seatData.counts[0] };
+      setServerSeats({ seats: [...seats], counts: seatData.counts[0] });
     });
   }, []);
 

--- a/client/src/stores/SeatStore.tsx
+++ b/client/src/stores/SeatStore.tsx
@@ -9,7 +9,7 @@ export const CountContext = React.createContext<any>(null);
 export function SeatStore({ children }: { children: React.ReactNode }) {
   const [serverSeats, dispatch] = useReducer(seatReducer, {
     seats: [],
-    counts: [],
+    counts: {},
   });
 
   const setServerSeats = (seats: any) => {
@@ -18,11 +18,17 @@ export function SeatStore({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     socket.on(
-      "receiveData",
+      "receiveSeat",
       (seatData: { seats: SeatInfo[]; counts: EmptySeatCount[] }) => {
+        console.log(seatData);
         setServerSeats(seatData);
       }
     );
+    socket.on("receiveCount", (seatData: { counts: Object[] }) => {
+      console.log(seatData);
+      console.log({ ...serverSeats, counts: seatData.counts[0] });
+      setServerSeats({ ...serverSeats, counts: seatData.counts[0] });
+    });
   }, []);
 
   return (

--- a/client/src/types/seatInfo.ts
+++ b/client/src/types/seatInfo.ts
@@ -2,6 +2,7 @@ export interface SeatInfo {
   id: string;
   color: string;
   name: string;
+  class: string;
   point: { x: number; y: number };
   status: string;
 }


### PR DESCRIPTION
## 구현 내용👩🏻‍💻
- [x] 소켓에서 잔여석과 좌석을 받아올 때 변경된 소켓 이벤트를 on하도록 변경하였습니다.
- [x] 회차선택페이지의 잔여석 정보가 좌석 선점 여부에 따라 실시간으로 변하도록 변경하였습니다.
## 고쳐야 할 것들👩🏻‍🔧
- [ ] 캔버스에서 좌석 취소시 잔여석정보에 잘못 반영됨
- [ ] 소켓에서 색상과 가격정보 받아와서 class를 key로 map으로 바꾸기
- [ ] 좌석선택 페이지에서 선택 좌석 정보의 색 디비에서 받아와서 보여주기(현재 소켓에서 받아온 seats에 저장되어있는 색을 뿌려주는데 다 같은 분홍색으로 설정되어 있는 듯  하다)