### PR TITLE
[J106] 회차선택 페이지에서 새로고침시 발생하는 문제 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,7 +9,7 @@ function App() {
         <Route path="/" exact component={ItemList} />
         <Route path="/seat" component={SeatSelection} />
         <Route path="/payment" component={Payment} />
-        <Route path="/schedule" component={SelectTime} />
+        <Route path="/schedule/:concertId" component={SelectTime} />
       </Switch>
     </BrowserRouter>
   );

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -142,6 +142,7 @@ export default function CalendarPicker({ setTimeDetail }) {
   });
 
   if (loading) return <p> loading.... </p>;
+  if (error) return <>`Error! ${error.message}`</>;
 
   const startDate = new Date(data.itemDetail.startDate);
   const endDate = new Date(data.itemDetail.endDate);
@@ -165,7 +166,6 @@ export default function CalendarPicker({ setTimeDetail }) {
       map[new Date(`${concert.year}-${concert.month}-${concert.date}`).getTime()] = concert;
       return map;
     }, {});
-
     const startMilesecond = new Date(
       `${startDate.getFullYear()}-${startDate.getMonth() + 1}-${startDate.getDate()}`,
     ).getTime();
@@ -174,7 +174,9 @@ export default function CalendarPicker({ setTimeDetail }) {
     ).getTime();
     let disableList = [];
     for (let i = startMilesecond; i <= endMilesecond; i += MILESCONT_PER_DAY) {
-      if (!scheduleMap[i]) disableList = [...disableList, new Date(i)];
+      if (!scheduleMap[i]) {
+        disableList = [...disableList, new Date(i)];
+      }
     }
     return disableList;
   };

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -113,7 +113,7 @@ const isSameDay = (a, b) => {
 
 const GET_SCHGEDULE = gql`
   query GetItem($id: ID) {
-    scheduleListByMonth(itemId: $id, startDate: "2020-12-1", endDate: "2021-02-01") {
+    scheduleListByMonth(itemId: $id) {
       _id
       date
     }

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -142,6 +142,8 @@ export default function CalendarPicker({ setTimeDetail }) {
   });
 
   if (loading) return <p> loading.... </p>;
+  if (error) return <>`Error! ${error.message}`</>;
+
   const startDate = new Date(data.itemDetail.startDate);
   const endDate = new Date(data.itemDetail.endDate);
 

--- a/client/src/components/ContentsArea/ContentsArea.tsx
+++ b/client/src/components/ContentsArea/ContentsArea.tsx
@@ -1,6 +1,6 @@
 import { Box, CardMedia } from "@material-ui/core";
 import { makeStyles, Theme, styled } from "@material-ui/core/styles";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, PropsWithRef } from "react";
 import { colors } from "../../styles/variables";
 import tmp from "../../imgs/tmp.jpg";
 import DateRangeOutlinedIcon from "@material-ui/icons/DateRangeOutlined";
@@ -9,6 +9,7 @@ import { useQuery, gql } from "@apollo/client";
 import { format } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useLocation } from "react-router-dom";
+import { Props } from "../../types/concertInfo";
 interface Price {
   price: number;
 }
@@ -69,7 +70,7 @@ const Poster = styled(CardMedia)((props) => ({
   backgroundSize: "cover",
   backgroundPosition: "50% 50%",
 }));
-export default function ContentsArea() {
+export default function ContentsArea({ concertId }: Props) {
   const classes = useStyles();
   const location: any = useLocation();
   const [itemId, setItemId] = useState<any>("");
@@ -88,13 +89,11 @@ export default function ContentsArea() {
     }
   `;
   useEffect(() => {
-    if (location.state) {
-      setItemId(location.state.itemId);
-    }
+    setItemId(concertId);
   }, []);
 
   const { loading, error, data } = useQuery(GET_ITEMS, {
-    variables: { id: itemId },
+    variables: { id: concertId },
   });
 
   if (loading) return <>"Loading..."</>;

--- a/client/src/components/ItemCardArea/ItemCard.tsx
+++ b/client/src/components/ItemCardArea/ItemCard.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useHistory } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { makeStyles } from "@material-ui/core/styles";
 import Card from "@material-ui/core/Card";
 import CardMedia from "@material-ui/core/CardMedia";
@@ -23,33 +23,27 @@ const useStyles = makeStyles((theme) => ({
 
 export default function ItemCard({ item }: ItemCardPropsInterface) {
   const cardStyles = useStyles();
-  const history = useHistory();
   const dispatch = useDispatch();
   const handleClick = () => {
-    dispatch(changeSelectedConcert(item._id, item.name));
-    const path = "/schedule";
-    history.push({
-      pathname: path,
-      state: {
-        itemId: item._id,
-      },
-    });
+    dispatch(changeSelectedConcert(item._id));
   };
 
   return (
-    <Card className={cardStyles.root} onClick={handleClick}>
-      <CardMedia className={cardStyles.media} image={item.img}></CardMedia>
-      <CardContent>
-        <Typography variant="body2" color="textSecondary" component="p">
-          {item.name}
-        </Typography>
-        <Typography variant="body2" color="textSecondary" component="p">
-          {item.place.name}
-        </Typography>
-        <Typography variant="body2" color="textSecondary" component="p">
-          {item.startDate}~{item.endDate}
-        </Typography>
-      </CardContent>
-    </Card>
+    <Link to={`/schedule/${item._id}`}>
+      <Card className={cardStyles.root} onClick={handleClick}>
+        <CardMedia className={cardStyles.media} image={item.img}></CardMedia>
+        <CardContent>
+          <Typography variant="body2" color="textSecondary" component="p">
+            {item.name}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" component="p">
+            {item.place.name}
+          </Typography>
+          <Typography variant="body2" color="textSecondary" component="p">
+            {item.startDate}~{item.endDate}
+          </Typography>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }

--- a/client/src/modules/concertInfo.ts
+++ b/client/src/modules/concertInfo.ts
@@ -1,9 +1,9 @@
 const CHANGE_SELECTED_CONCERT = "concertInfo/CHANGE_SELECTED_CONCERT" as const;
 const SELECT_SCHEDULE = "concertInfo/SELECT_SCHEDULE" as const;
 
-export const changeSelectedConcert = (id: string, name: string) => ({
+export const changeSelectedConcert = (id: string) => ({
   type: CHANGE_SELECTED_CONCERT,
-  payload: { id, name },
+  payload: id,
 });
 
 export const selectSchedule = (id: string) => ({
@@ -19,8 +19,8 @@ export interface ConcertInfo {
   price?: string;
   startDate?: string;
   endDate?: string;
-  //runningTime: string;
-  //class: number;
+  runningTime?: string;
+  class?: string;
 }
 
 type ConcertInfoAction =
@@ -36,8 +36,8 @@ const initialState: ConcertInfoState = {
   price: undefined,
   startDate: undefined,
   endDate: undefined,
-  //runningTime: "2시간 45분",
-  //class: "8세이상 관람가",
+  runningTime: "2시간 45분",
+  class: "8세이상 관람가",
 };
 
 const concertInfoReducer = (
@@ -48,8 +48,7 @@ const concertInfoReducer = (
     case CHANGE_SELECTED_CONCERT:
       return {
         ...state,
-        id: action.payload.id,
-        name: action.payload.name,
+        id: action.payload,
       };
     case SELECT_SCHEDULE:
       return {

--- a/client/src/modules/concertInfo.ts
+++ b/client/src/modules/concertInfo.ts
@@ -47,6 +47,7 @@ const concertInfoReducer = (
   switch (action.type) {
     case CHANGE_SELECTED_CONCERT:
       return {
+        ...state,
         id: action.payload.id,
         name: action.payload.name,
       };

--- a/client/src/pages/SeatSelection.tsx
+++ b/client/src/pages/SeatSelection.tsx
@@ -1,7 +1,15 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MainHeader, SeatSelectionBox } from "../components";
+import useConcertInfo from "../hooks/useConcertInfo";
+import { useHistory } from "react-router-dom";
 
 export default function SeatSelection() {
+  const concertInfo = useConcertInfo();
+  const history = useHistory();
+
+  useEffect(() => {
+    if (concertInfo.id === "") history.goBack();
+  }, []);
   return (
     <>
       <MainHeader title="좌석선택하기" />

--- a/client/src/pages/SelectTime.tsx
+++ b/client/src/pages/SelectTime.tsx
@@ -1,13 +1,38 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { MainHeader, ContentsArea, ConcertDetails } from "../components";
-import useConcertInfo from "../hooks/useConcertInfo";
+import { useParams } from "react-router-dom";
+import { useQuery, gql } from "@apollo/client";
+import { useDispatch } from "react-redux";
+import { changeSelectedConcert } from "../modules/concertInfo";
+
+interface Params {
+  concertId: string;
+}
 
 export default function SelectTime() {
-  const concertInfo = useConcertInfo();
+  const dispatch = useDispatch();
+  const { concertId } = useParams<Params>();
+  const GET_TITLE = gql`
+    query GetItem($id: ID) {
+      itemDetail(itemId: $id) {
+        name
+      }
+    }
+  `;
+  useEffect(() => {
+    dispatch(changeSelectedConcert(concertId));
+  }, []);
+  const { loading, error, data } = useQuery(GET_TITLE, {
+    variables: { id: concertId },
+  });
+
+  if (loading) return <p> loading.... </p>;
+  if (error) return <>`Error! ${error.message}`</>;
+  const { name } = data.itemDetail;
   return (
     <>
-      <MainHeader title={concertInfo.name} />
-      <ContentsArea />
+      <MainHeader title={name} />
+      <ContentsArea concertId={concertId} />
       <ConcertDetails />
     </>
   );

--- a/client/src/types/concertInfo.ts
+++ b/client/src/types/concertInfo.ts
@@ -11,3 +11,7 @@ export interface SelectedConcertInfo {
   time: string;
   price: Prices[];
 }
+
+export interface Props {
+  concertId: string;
+}


### PR DESCRIPTION
## 수정 내용
- url의 params로 콘서트 id를 받아와서 새로고침 할 때 전역 스토어를 다시 설정해주도록 변경
- 좌석선택 페이지에서는 전역스토어의 concertId가 없으면 이전 페이지로 돌아가도록 함.