### PR TITLE
[J106] 결제페이지 구현

### DIFF
--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -7,7 +7,7 @@ import { colors } from "../../../styles/variables";
 import { Box, Button } from "@material-ui/core";
 import DateRangeIcon from "@material-ui/icons/DateRange";
 import { EmptySeatsCount } from "../../common";
-import { useHistory, useParams } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 import { ko } from "date-fns/locale";
 import { useQuery, gql } from "@apollo/client";
 import { DnsTwoTone } from "@material-ui/icons";
@@ -16,9 +16,6 @@ import useConcertInfo from "../../../hooks/useConcertInfo";
 import { useDispatch } from "react-redux";
 import { selectSchedule } from "../../../modules/concertInfo";
 
-// const muiTheme = createMuiTheme({
-//   palette: { primary: colors.naverWhite, secondary: colors.naverBlue },
-// });
 const useStyles = makeStyles(() => ({
   calendar: {
     width: "100%",

--- a/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
+++ b/client/src/components/ConcertDetails/CalendarPicker/CalendarPicker.js
@@ -206,9 +206,16 @@ export default function CalendarPicker({ setTimeDetail }) {
     setValue(value);
   };
   // TODO: 해당 시간 클릭하면 그 box만 색칠하기.(다른 시간이 선택되어있었으면 그 box 다시 흰색으로 바꾸기)
-  const handleOnClick = (e) => {
-    setSelectedConcertId(e.target.id);
-    dispatch(selectSchedule(e.target.id));
+  const handleOnClick = (concert) => {
+    const dateDetail = format(
+      new Date(concert.year, concert.month, concert.date, concert.hour, concert.minute),
+      "yyyy. M. d. (ccc), a h:mm",
+      {
+        locale: ko,
+      },
+    );
+    setSelectedConcertId(concert.id);
+    dispatch(selectSchedule(concert.id, dateDetail));
     //socket.emit("leaveCountRoom", scheduleID);
     socket.emit("joinCountRoom", "A");
   };
@@ -249,7 +256,7 @@ export default function CalendarPicker({ setTimeDetail }) {
               <TimeBox
                 key={concert.id}
                 id={concert.id}
-                onClick={handleOnClick}
+                onClick={() => handleOnClick(concert)}
                 color={concert.id === selectedConcertId ? colors.naverBlue : colors.naverWhite}
                 fontcolor={
                   concert.id === selectedConcertId ? colors.naverWhite : colors.naverFontBlack
@@ -258,7 +265,11 @@ export default function CalendarPicker({ setTimeDetail }) {
                   concert.id === selectedConcertId ? colors.naverWhite : colors.naverBlue
                 }
               >
-                <span className={classes.timeItemTitle} id={concert.id} onClick={handleOnClick}>
+                <span
+                  className={classes.timeItemTitle}
+                  id={concert.id}
+                  onClick={() => handleOnClick(concert)}
+                >
                   {format(new Date(0, 0, 0, concert.hour, concert.minute), "a h:mm", {
                     locale: ko,
                   })}

--- a/client/src/components/ContentsArea/ContentsArea.tsx
+++ b/client/src/components/ContentsArea/ContentsArea.tsx
@@ -85,6 +85,8 @@ export default function ContentsArea({ concertId }: Props) {
           price
         }
         img
+        runningTime
+        ageLimit
       }
     }
   `;
@@ -98,7 +100,7 @@ export default function ContentsArea({ concertId }: Props) {
 
   if (loading) return <>"Loading..."</>;
   if (error) return <>`Error! ${error.message}`</>;
-  const { name, startDate, endDate, prices, img } = data.itemDetail;
+  const { name, startDate, endDate, prices, img, runningTime, ageLimit } = data.itemDetail;
   const pricesArr = prices.map((price: Price) => price.price);
 
   return (
@@ -130,7 +132,9 @@ export default function ContentsArea({ concertId }: Props) {
             </Box>
             <Box className={classes.infoRow}>
               <PlayCircleFilledWhiteOutlinedIcon className={classes.infoIcon} fontSize="small" />
-              <span>2시간, 8세 이상 관람가</span>
+              <span>
+                {runningTime}, {ageLimit}
+              </span>
             </Box>
           </Box>
         </Box>

--- a/client/src/components/MainHeader/MainHeader.tsx
+++ b/client/src/components/MainHeader/MainHeader.tsx
@@ -44,7 +44,7 @@ export default function MainHeader({ title }: props) {
             <ArrowBackIcon />
           </IconButton>
           <Typography variant="h6" className={classes.title}>
-            {title}
+            {title.length <= 18 ? title : title.substring(0, 17) + "..."}
           </Typography>
           <MyButton color="inherit">MY</MyButton>
         </Box>

--- a/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
+++ b/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect } from "react";
+import { Box } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { colors } from "../../styles/variables";
+import { useQuery, gql } from "@apollo/client";
+import { useHistory, Link } from "react-router-dom";
+import useSeats from "../../hooks/useSeats";
+import useConcertInfo from "../../hooks/useConcertInfo";
+import { Badge, StepButton } from "../common";
+
+const useStyles = makeStyles(() => ({
+  selectInfo: {
+    padding: "0 21px",
+    backgroundColor: colors.naverWhite,
+    borderBottom: `1px solid ${colors.borderLightGray}`,
+  },
+  title: {
+    position: "relative",
+    paddingBottom: "8px",
+  },
+  text: {
+    display: "inline-block",
+    paddingTop: "19px",
+    fontSize: "21px",
+    color: colors.naverFontBlack,
+    letterSpacing: "-0.5px",
+  },
+  date: {
+    padding: "2px 48px 0 0",
+    color: colors.naverFontDarkGray,
+    letterSpacing: "-0.3px",
+  },
+  changeBtn: {
+    position: "absolute",
+    bottom: "6px",
+    right: "0",
+    height: "28px",
+    padding: "0 10px",
+    backgroundColor: "#3794ff",
+    borderRadius: "3px",
+    color: colors.naverWhite,
+    lineHeight: "28px",
+  },
+  seatInfo: {
+    padding: "6px 0 15px",
+    borderTop: `1px solid ${colors.borderLightGray}`,
+  },
+  grade: {
+    display: "table-row",
+    tableLayout: "fixed",
+  },
+  gradeText: {
+    display: "table-cell",
+    padding: "4px 16px 0 0",
+    fontWeight: "bold",
+    fontSize: "16px",
+  },
+  seatText: {
+    display: "table-cell",
+    fontSize: "16px",
+  },
+  total: {
+    marginTop: "14px",
+    marginBottom: "20px",
+    padding: "8px 8px 10px",
+    background: "#f2f2f2",
+    borderTop: "1px solid #e3e3e3",
+  },
+  price: {
+    float: "right",
+    textAlign: "right",
+    fontSize: "18px",
+    letterSpacing: "-0.3px",
+    color: "#ff5658",
+  },
+}));
+
+export default function PaymentSelectionBox() {
+  const classes = useStyles();
+  const concertInfo = useConcertInfo();
+  const seats = useSeats();
+
+  const history = useHistory();
+  const GET_INFO = gql`
+    query GetInfo($id: ID) {
+      itemDetail(itemId: $id) {
+        name
+        prices {
+          class
+          price
+        }
+      }
+    }
+  `;
+  const { loading, error, data } = useQuery(GET_INFO, {
+    variables: { id: concertInfo.id },
+  });
+
+  const onClickChage = () => {
+    history.replace(`/schedule/${concertInfo.id}`);
+  };
+
+  useEffect(() => {
+    if (concertInfo.id === "") history.goBack();
+  }, []);
+
+  if (loading) return <p> loading.... </p>;
+  if (error) return <>`Error! ${error.message}`</>;
+  const { name, prices } = data.itemDetail;
+  const price = prices.reduce((acc: any, value: any, idx: any, arr: any) => {
+    acc[value.class] = value.price;
+    return acc;
+  }, {});
+
+  const sum = seats.selectedSeat.reduce((acc, cur, i) => {
+    return acc + price[cur.class];
+  }, 0);
+
+  return (
+    <>
+      <Box className={classes.selectInfo}>
+        <Box className={classes.title}>
+          <strong className={classes.text}>{name}</strong>
+          <Box className={classes.date}>
+            {concertInfo.dateDetail}, 총 {seats.selectedSeat.length}매
+          </Box>
+          <Box className={classes.changeBtn} onClick={onClickChage}>
+            변경
+          </Box>
+        </Box>
+        <Box className={classes.seatInfo}>
+          {seats.selectedSeat.map((seat, idx) => {
+            return (
+              <Box key={idx} className={classes.grade}>
+                <Box className={classes.gradeText}>
+                  <Badge component="span" color={seat.color} />
+                  <span>{seat.class}</span>
+                </Box>
+                <Box className={classes.seatText}>{seat.name}</Box>
+              </Box>
+            );
+          })}
+        </Box>
+        <Box className={classes.total}>
+          <span>합계</span>
+          <strong className={classes.price}>{sum}</strong>
+        </Box>
+      </Box>
+      <StepButton link="/" next="결제완료" />
+    </>
+  );
+}

--- a/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
@@ -10,10 +10,8 @@ import { useHistory } from "react-router-dom";
 import { useQuery, gql } from "@apollo/client";
 import { SeatContext } from "../../../stores/SeatStore";
 import useConcertInfo from "../../../hooks/useConcertInfo";
+import { StepButton, Badge } from "../../common";
 
-interface styleProps {
-  color: string;
-}
 interface SeatInfo {
   color: string;
   price: number;
@@ -99,39 +97,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   cancel: {
     cursor: "pointer",
   },
-  stepBtn: {
-    padding: "6px",
-    backgroundColor: "#efefef",
-    borderTop: "1px solid #dbdbdb",
-  },
-  beforeBtn: {
-    width: "39%",
-    height: "51px",
-    marginRight: "1%",
-    backgroundColor: `${colors.naverWhite}`,
-    borderRadius: "0",
-    border: `1px solid rgba(0,0,0,0.15)`,
-    fontWeight: "bold",
-  },
-  nextBtn: {
-    width: "59%",
-    height: "51px",
-    marginLeft: "1%",
-    backgroundColor: `${colors.naverGreen}`,
-    borderRadius: "0",
-    fontWeight: "bold",
-    fontColor: `${colors.naverWhite}`,
-  },
-}));
-
-const Badge = styled(Box)((props: styleProps) => ({
-  display: "inline-block",
-  marginTop: "4px",
-  width: "13px",
-  height: "13px",
-  top: "3px",
-  marginRight: "0.5rem",
-  backgroundColor: props.color,
 }));
 
 const unsold = "#01DF3A";
@@ -163,18 +128,6 @@ export default function SeatInfoArea() {
     cancelSeat(seat.id);
     socket.emit("clickSeat", "A", seat);
   };
-
-  const handleClickPre = () => {
-    history.goBack();
-  };
-
-  const handleClickNext = () => {
-    const paymentLink = "/payment";
-    history.push({
-      pathname: paymentLink,
-    });
-  };
-
   useEffect(() => {
     socket.emit("joinBookingRoom", "A");
     setSeatsCount({ ...serverSeats.counts });
@@ -238,24 +191,7 @@ export default function SeatInfoArea() {
           </Box>
         </Box>
       </Paper>
-      <Box className={classes.stepBtn}>
-        <Button
-          size="large"
-          variant="contained"
-          onClick={handleClickPre}
-          className={classes.beforeBtn}
-        >
-          이전단계
-        </Button>
-        <Button
-          size="large"
-          variant="contained"
-          onClick={handleClickNext}
-          className={classes.nextBtn}
-        >
-          다음단계
-        </Button>
-      </Box>
+      <StepButton link="/payment" next="다음단계" />
     </>
   );
 }

--- a/client/src/components/SeatSelectionBox/SeatSelectionBox.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionBox.tsx
@@ -3,23 +3,15 @@ import SeatSelectedHeader from "./SeatSelectionHeader/SeatSelectionHeader";
 import SeatSelectedArea from "./SeatSelectionArea/SeatSelectionArea";
 import SeatInfoArea from "./SeatInfoArea/SeatInfoArea";
 import { useDispatch } from "react-redux";
+import useConcertInfo from "../../hooks/useConcertInfo";
 import { create } from "../../modules/socket";
 import useSocket from "../../hooks/useSocket";
 
 // TODO: SeatSelectionBox의 props로 공연 회차 정보 받아오기. -> useContext사용 고려
 export default function SeatSelectionBox() {
-  const dispatch = useDispatch();
+  const concertInfo = useConcertInfo();
   // const socket = useSocket();
   useEffect(() => {
-    // dispatch(create());
-    /*
-    TODO: socket.on에 대한 처리들
-    ex)
-    socket.on("receiveData", (data: any) => {
-      console.log(data);
-      // 이곳에서 redux의 상태 변화시켜주기
-    });
-    */
     return () => {
       // TODO: 페이지 이동시 emit
     };
@@ -27,7 +19,7 @@ export default function SeatSelectionBox() {
   // TODO: SeatSelectHeader의 props로 공연 회차 정보 넘겨주기 -> 공연 회차 정보도 redux 사용?
   return (
     <>
-      <SeatSelectedHeader dateInfo="2020. 11. 28. (토), 오후 03:00" />
+      <SeatSelectedHeader dateInfo={concertInfo.dateDetail} />
       <SeatSelectedArea />
       <SeatInfoArea />
     </>

--- a/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
+++ b/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
@@ -8,6 +8,9 @@ import { EmptySeatCount } from "../../../types/seatInfo";
 import { socket } from "../../../socket";
 import { useQuery, gql } from "@apollo/client";
 import useConcertInfo from "../../../hooks/useConcertInfo";
+import { Prices } from "../../../types/concertInfo";
+import { useDispatch } from "react-redux";
+import { setPrice } from "../../../modules/concertInfo";
 
 interface styleProps {
   color: string;
@@ -72,7 +75,8 @@ export default function EmptySeatsCount() {
   const [seatsCount, setSeatsCount] = useState<any>({});
   const { serverSeats } = useContext(SeatContext);
   const concertInfo = useConcertInfo();
-  let seatInfo: SeatInfo[] = [];
+  const dispatch = useDispatch();
+  let seatInfo: Prices[] = [];
 
   const GET_ITEMS = gql`
     query ItemDetail($id: ID) {
@@ -107,6 +111,7 @@ export default function EmptySeatsCount() {
   if (data) {
     seatInfo = data.itemDetail.classes.map((value: any, index: number) => {
       return {
+        class: value.class,
         color: value.color,
         price: data.itemDetail.prices[index].price,
       };

--- a/client/src/components/common/StepButton/StepButton.tsx
+++ b/client/src/components/common/StepButton/StepButton.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { Box, Button } from "@material-ui/core";
+import { makeStyles, Theme } from "@material-ui/core/styles";
+import { colors } from "../../../styles/variables";
+import { useHistory } from "react-router-dom";
+import { socket } from "../../../socket";
+
+interface Props {
+  link: string;
+  next: string;
+}
+
+const useStyles = makeStyles((theme: Theme) => ({
+  stepBtn: {
+    position: "fixed",
+    width: "402px",
+    bottom: "0",
+    padding: "6px",
+    backgroundColor: "#efefef",
+    borderTop: "1px solid #dbdbdb",
+  },
+  beforeBtn: {
+    width: "39%",
+    height: "51px",
+    marginRight: "1%",
+    backgroundColor: `${colors.naverWhite}`,
+    borderRadius: "0",
+    border: `1px solid rgba(0,0,0,0.15)`,
+    fontWeight: "bold",
+  },
+  nextBtn: {
+    width: "59%",
+    height: "51px",
+    marginLeft: "1%",
+    backgroundColor: `${colors.naverGreen}`,
+    borderRadius: "0",
+    fontWeight: "bold",
+    fontColor: `${colors.naverWhite}`,
+  },
+}));
+
+export default function StepButton({ link, next }: Props) {
+  const history = useHistory();
+  const classes = useStyles();
+
+  const handleClickPre = () => {
+    history.goBack();
+  };
+
+  const handleClickNext = () => {
+    if (next === "결제완료") {
+    }
+    history.replace({
+      pathname: link,
+    });
+  };
+  return (
+    <Box className={classes.stepBtn}>
+      <Button
+        size="large"
+        variant="contained"
+        onClick={handleClickPre}
+        className={classes.beforeBtn}
+      >
+        이전단계
+      </Button>
+      <Button
+        size="large"
+        variant="contained"
+        onClick={handleClickNext}
+        className={classes.nextBtn}
+      >
+        {next}
+      </Button>
+    </Box>
+  );
+}

--- a/client/src/components/common/index.ts
+++ b/client/src/components/common/index.ts
@@ -1,1 +1,19 @@
+import { styled } from "@material-ui/core/styles";
+import Box from "@material-ui/core/Box";
+
+interface styleProps {
+  color: string;
+}
+
 export { default as EmptySeatsCount } from "./EmptySeatsCount/EmptySeatsCount";
+export { default as StepButton } from "./StepButton/StepButton";
+
+export const Badge = styled(Box)((props: styleProps) => ({
+  display: "inline-block",
+  marginTop: "4px",
+  width: "13px",
+  height: "13px",
+  top: "3px",
+  marginRight: "0.5rem",
+  backgroundColor: props.color,
+}));

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -2,3 +2,4 @@ export { default as MainHeader } from "./MainHeader/MainHeader";
 export { default as SeatSelectionBox } from "./SeatSelectionBox/SeatSelectionBox";
 export { default as ContentsArea } from "./ContentsArea/ContentsArea";
 export { default as ConcertDetails } from "./ConcertDetails/ConcertDetails";
+export { default as PaymentSelectInfo } from "./PaymentSelectInfo/PaymentSelectInfo";

--- a/client/src/modules/concertInfo.ts
+++ b/client/src/modules/concertInfo.ts
@@ -1,22 +1,30 @@
+import { Prices } from "../types/concertInfo";
+
 const CHANGE_SELECTED_CONCERT = "concertInfo/CHANGE_SELECTED_CONCERT" as const;
 const SELECT_SCHEDULE = "concertInfo/SELECT_SCHEDULE" as const;
+const SET_PRICE = "concertInfo/SET_PRICE" as const;
 
 export const changeSelectedConcert = (id: string) => ({
   type: CHANGE_SELECTED_CONCERT,
   payload: id,
 });
 
-export const selectSchedule = (id: string) => ({
+export const selectSchedule = (id: string, dateDetail: string) => ({
   type: SELECT_SCHEDULE,
-  payload: id,
+  payload: { id, dateDetail },
+});
+
+export const setPrice = (prices: Prices[]) => ({
+  type: SET_PRICE,
+  payload: prices,
 });
 
 export interface ConcertInfo {
   id: string;
   name: string;
   scheduleId?: string;
-  date?: string;
-  price?: string;
+  dateDetail: string;
+  price?: Prices[];
   startDate?: string;
   endDate?: string;
   runningTime?: string;
@@ -25,7 +33,8 @@ export interface ConcertInfo {
 
 type ConcertInfoAction =
   | ReturnType<typeof changeSelectedConcert>
-  | ReturnType<typeof selectSchedule>;
+  | ReturnType<typeof selectSchedule>
+  | ReturnType<typeof setPrice>;
 
 type ConcertInfoState = ConcertInfo;
 
@@ -33,6 +42,7 @@ const initialState: ConcertInfoState = {
   id: "",
   name: "",
   scheduleId: undefined,
+  dateDetail: "",
   price: undefined,
   startDate: undefined,
   endDate: undefined,
@@ -53,7 +63,13 @@ const concertInfoReducer = (
     case SELECT_SCHEDULE:
       return {
         ...state,
-        scheduleId: action.payload,
+        scheduleId: action.payload.id,
+        dateDetail: action.payload.dateDetail,
+      };
+    case SET_PRICE:
+      return {
+        ...state,
+        price: action.payload,
       };
     default:
       return state;

--- a/client/src/pages/Payment.tsx
+++ b/client/src/pages/Payment.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { MainHeader } from "../components";
+import { MainHeader, PaymentSelectInfo } from "../components";
 
 export default function Payment() {
   return (
     <>
       <MainHeader title="결제하기" />
+      <PaymentSelectInfo />
     </>
   );
 }

--- a/client/src/styles/variables.ts
+++ b/client/src/styles/variables.ts
@@ -3,6 +3,7 @@ export const colors = {
   naverWhite: "#fff",
   naverRed: "#ff5658",
   naverFontBlack: "#242424",
+  naverFontDarkGray: "#424242",
   naverFontSub: "#666",
   naverBlue: "#3787ff",
   naverBtnGreen: "#00d780",

--- a/client/src/types/concertInfo.ts
+++ b/client/src/types/concertInfo.ts
@@ -1,4 +1,4 @@
-interface Prices {
+export interface Prices {
   color: string;
   class: string;
   price: number;


### PR DESCRIPTION
## 구현 내용
- [x] 결제화면에서 간단한 공연 정보(선택 회차, 선택 좌석)와 금액 합계 보여주기
## 해야할 것
- [ ] 결제완료 버튼 누르면 GraphQL 서버로 예약 내용 보내고 선택 좌석 상태 초기화하기
## 스크린샷
![image](https://user-images.githubusercontent.com/37579982/101523367-dd5dfa00-39cb-11eb-8ece-a18aa84d869a.png)
