### PR TITLE
[J106] 각종 버그 수정, 전역스토어 수정, 마이페이지 구현

### DIFF
--- a/api-server/schemas/types.ts
+++ b/api-server/schemas/types.ts
@@ -51,7 +51,7 @@ const typeDefs = gql`
 
   type Schedule {
     _id: ID
-    date: ISODate
+    date: String
     seatGroups: [Class]
   }
 

--- a/api-server/schemas/types.ts
+++ b/api-server/schemas/types.ts
@@ -51,7 +51,7 @@ const typeDefs = gql`
 
   type Schedule {
     _id: ID
-    date: String
+    date: ISODate
     seatGroups: [Class]
   }
 
@@ -68,7 +68,7 @@ const typeDefs = gql`
   type Booking {
     _id: ID
     item: Item
-    schedule: Schedule
+    schedule: BookedSchedule
     seats: [BookingSeat]
   }
 
@@ -95,6 +95,11 @@ const typeDefs = gql`
     price: Int
   }
 
+  type BookedSchedule {
+    _id: ID
+    date: String
+  }
+
   input ItemInput {
     _id: ID
     name: String
@@ -112,6 +117,7 @@ const typeDefs = gql`
   }
 
   input SeatInput {
+    _id: ID
     name: String
     class: String
   }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,14 @@
 import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
-import { SeatSelection, SelectTime, Payment, ItemList, Login, MyPage } from "./pages";
+import {
+  SeatSelection,
+  SelectTime,
+  Payment,
+  ItemList,
+  Login,
+  MyPage,
+  BookingCancel,
+} from "./pages";
 
 function App() {
   return (
@@ -12,6 +20,7 @@ function App() {
         <Route path="/login" component={Login} />
         <Route path="/schedule/:concertId" component={SelectTime} />
         <Route path="/mypage" component={MyPage} />
+        <Route path="/cancel" component={BookingCancel} />
       </Switch>
     </BrowserRouter>
   );

--- a/client/src/components/BookingCancelArea/BookingCancelArea.tsx
+++ b/client/src/components/BookingCancelArea/BookingCancelArea.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { makeStyles } from "@material-ui/core/styles";
+import { Box } from "@material-ui/core";
+import { useQuery, gql } from "@apollo/client";
+import { useDispatch } from "react-redux";
+import { useHistory, useLocation } from "react-router-dom";
+import { colors } from "../../styles/variables";
+import { socket } from "../../socket";
+
+const useStyles = makeStyles(() => ({}));
+
+export default function BookingCancelArea() {
+  const [userName, setUserName] = useState("");
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const classes = useStyles();
+  const [booking, setBooking] = useState<any>();
+  const location = useLocation();
+
+  useEffect(() => {
+    socket.emit("willCancelBooking", booking.schedule._id, booking.seats);
+  }, []);
+  return <></>;
+}

--- a/client/src/components/ItemFilterArea/ItemFilter.tsx
+++ b/client/src/components/ItemFilterArea/ItemFilter.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles(() => ({
     color: "#fff",
     opacity: 0.5,
 
-    "&$selected": {
+    "& $selected": {
       color: "#fff",
       opacity: 1,
     },

--- a/client/src/components/MyPageArea/MyPageArea.tsx
+++ b/client/src/components/MyPageArea/MyPageArea.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { TextField, Button } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import { Box } from "@material-ui/core";
+import { useMutation, gql } from "@apollo/client";
+import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
+import { setUser } from "../../modules/user";
+import { colors } from "../../styles/variables";
+
+const LOGIN = gql`
+  mutation login($userName: String) {
+    loginUser(userName: $userName) {
+      _id
+      userName
+    }
+  }
+`;
+
+const useStyles = makeStyles(() => ({
+  userInfoArea: {
+    padding: "22px 20px 0",
+    backgroundColor: colors.naverWhite,
+    marginTop: "12px",
+    boxShadow: "0 2px 6px 0 rgba(0,0,0,0.05), 0 0 1px 0 rgba(0,21,81,0.05)",
+  },
+  titleText: {
+    color: colors.myPageBlack,
+    fontSize: "20px",
+    lineHeight: "28px",
+    letterSpacing: "-0.4px",
+    wordBreak: "keep-all",
+  },
+  point: {
+    color: colors.myPagePurple,
+  },
+}));
+
+export default function MyPageArea() {
+  const [userName, setUserName] = useState("");
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const [login] = useMutation(LOGIN);
+  const classes = useStyles();
+
+  return (
+    <>
+      <Box className={classes.userInfoArea}>
+        <strong className={classes.titleText}>
+          어서오세요, <span className={classes.point}>{localStorage.userName}</span>님!
+        </strong>
+      </Box>
+    </>
+  );
+}

--- a/client/src/components/MyPageArea/MyPageArea.tsx
+++ b/client/src/components/MyPageArea/MyPageArea.tsx
@@ -1,27 +1,17 @@
-import React, { useState } from "react";
-import { TextField, Button } from "@material-ui/core";
+import React, { useState, useEffect, useMemo } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { Box } from "@material-ui/core";
-import { useMutation, gql } from "@apollo/client";
+import { useQuery, gql } from "@apollo/client";
 import { useDispatch } from "react-redux";
 import { useHistory } from "react-router-dom";
-import { setUser } from "../../modules/user";
 import { colors } from "../../styles/variables";
-
-const LOGIN = gql`
-  mutation login($userName: String) {
-    loginUser(userName: $userName) {
-      _id
-      userName
-    }
-  }
-`;
 
 const useStyles = makeStyles(() => ({
   userInfoArea: {
-    padding: "22px 20px 0",
+    padding: "22px 20px",
     backgroundColor: colors.naverWhite,
     marginTop: "12px",
+    marginBottom: "8px",
     boxShadow: "0 2px 6px 0 rgba(0,0,0,0.05), 0 0 1px 0 rgba(0,21,81,0.05)",
   },
   titleText: {
@@ -34,21 +24,133 @@ const useStyles = makeStyles(() => ({
   point: {
     color: colors.myPagePurple,
   },
+  card: {
+    marginTop: "13px",
+    backgroundColor: colors.naverWhite,
+    borderRadius: "15px",
+    boxShadow: "0 2px 6px 0 rgba(0,0,0,0.05), 0 0 1px 0 rgba(0,21,81,0.05)",
+  },
+  upperBox: {
+    overflow: "hidden",
+    margin: "0 24px",
+    padding: "19px 0 16px",
+    borderBottom: "1px dashed #e4e8ed",
+  },
+  highlight: {
+    boxShadow: "inset 0 -5px 0 #e0f7f4",
+    fontSize: "15px",
+    fontWeight: "bold",
+    letterSpacing: "-0.3px",
+    color: "#333",
+  },
+  lowerBox: {
+    display: "flex",
+    margin: "0 24px",
+    padding: "19px 0",
+  },
+  info: {
+    flex: 4,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    fontSize: "16px",
+    fontWeight: "bold",
+    letterSpacing: "-0.3px",
+    color: "#333",
+  },
+  cancelBtn: {
+    flex: 1,
+    display: "flex",
+    justifyContent: "center",
+    height: "28px",
+    padding: "0 5px",
+    fontSize: "14px",
+    backgroundColor: colors.myPagePurple,
+    borderRadius: "3px",
+    color: colors.naverWhite,
+    lineHeight: "28px",
+    cursor: "pointer",
+  },
 }));
 
 export default function MyPageArea() {
   const [userName, setUserName] = useState("");
   const dispatch = useDispatch();
   const history = useHistory();
-  const [login] = useMutation(LOGIN);
   const classes = useStyles();
+  const [bookingList, setBookingList] = useState<any>([]);
 
+  const GET_BOOKING_LIST = gql`
+    query BookingListByUserId($userId: ID) {
+      bookingListByUserId(userId: $userId) {
+        _id
+        item {
+          name
+        }
+        schedule {
+          _id
+          date
+        }
+        seats {
+          _id
+          class
+          name
+          status
+          color
+        }
+      }
+    }
+  `;
+  const { loading, error, data } = useQuery(GET_BOOKING_LIST, {
+    variables: { userId: localStorage.getItem("userid") },
+  });
+
+  useEffect(() => {
+    console.log(1);
+    if (data) {
+      setBookingList([...data.bookingListByUserId]);
+      console.log(bookingList);
+      console.log(2);
+    }
+  }, [data]);
+
+  const handleClickCancel = (e: any) => {
+    history.push({
+      pathname: "/cancel",
+      state: {
+        booking: data.bookingListByUserId[e.target.id],
+      },
+    });
+  };
+  if (loading) return <>"Loading..."</>;
+  if (error) return <>`Error! ${error.message}`</>;
+  console.log(data.bookingListByUserId);
   return (
     <>
       <Box className={classes.userInfoArea}>
         <strong className={classes.titleText}>
           어서오세요, <span className={classes.point}>{localStorage.userName}</span>님!
+          <br />총 <span className={classes.point}>{bookingList.length}</span>개의 예매내역이
+          있습니다.
         </strong>
+      </Box>
+      <Box className={classes.userInfoArea}>
+        <strong className={classes.titleText}>취소 가능한 예약</strong>
+        {data.bookingListByUserId.map((element: any, idx: any) => {
+          return (
+            <Box key={idx} className={classes.card}>
+              <Box className={classes.upperBox}>
+                <span className={classes.highlight}>{element.item.name}</span>
+              </Box>
+              <Box className={classes.lowerBox}>
+                <Box className={classes.info}>{element.schedule.date}</Box>
+                <Box id={idx} className={classes.cancelBtn} onClick={handleClickCancel}>
+                  예매 취소
+                </Box>
+              </Box>
+            </Box>
+          );
+        })}
       </Box>
     </>
   );

--- a/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
+++ b/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles(() => ({
   },
   seatText: {
     display: "table-cell",
+    width: "40%",
     paddingRight: "16px",
     fontSize: "16px",
   },
@@ -112,10 +113,6 @@ export default function PaymentSelectionBox() {
     query GetInfo($id: ID) {
       itemDetail(itemId: $id) {
         name
-        prices {
-          class
-          price
-        }
       }
     }
   `;
@@ -127,28 +124,17 @@ export default function PaymentSelectionBox() {
     history.replace(`/schedule/${concertInfo.id}`);
   };
 
-  useEffect(() => {
-    if (concertInfo.id === "") history.goBack();
-    if (!concertInfo.scheduleId || concertInfo.dateDetail === "")
-      history.replace("/schedule/" + concertInfo.id);
-    if (!localStorage.getItem("userid")) history.replace("/login");
-  }, []);
-
   if (loading) return <p> loading.... </p>;
   if (error) return <>`Error! ${error.message}`</>;
-  const { name, prices } = data.itemDetail;
-  const price = prices.reduce((acc: any, value: any, idx: any, arr: any) => {
-    acc[value.class] = value.price;
-    return acc;
-  }, {});
+  const { name } = data.itemDetail;
 
   const sum = seats.selectedSeat.reduce((acc, cur, i) => {
-    return acc + price[cur.class];
+    return acc + concertInfo.prices[cur.class];
   }, 0);
 
   const clickPay = () => {
     const seatsData = seats.selectedSeat.map((seat: any) => {
-      return { name: seat.name, class: seat.class };
+      return { _id: seat._id, name: seat.name, class: seat.class };
     });
     bookItem({
       variables: {
@@ -183,11 +169,13 @@ export default function PaymentSelectionBox() {
             return (
               <Box key={idx} className={classes.grade}>
                 <Box className={classes.gradeText}>
-                  <Badge component="span" color={seat.color} />
+                  <Badge component="span" color={concertInfo.colors[seat.class]} />
                   <span>{seat.class}</span>
                 </Box>
                 <Box className={classes.seatText}>{seat.name}</Box>
-                <Box className={classes.priceText}>{intl.format(price[seat.class])}원</Box>
+                <Box className={classes.priceText}>
+                  {intl.format(concertInfo.prices[seat.class])}원
+                </Box>
               </Box>
             );
           })}

--- a/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
+++ b/client/src/components/PaymentSelectInfo/PaymentSelectInfo.tsx
@@ -107,7 +107,7 @@ export default function PaymentSelectionBox() {
     }
   `;
   const [bookItem, { data: bookData, error: mutationError }] = useMutation(BOOK_ITEM);
-  console.log(mutationError);
+
   const GET_INFO = gql`
     query GetInfo($id: ID) {
       itemDetail(itemId: $id) {

--- a/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
@@ -126,10 +126,9 @@ export default function SeatInfoArea() {
   const handleClickCancel = (seat: any) => {
     seat.status = "clicked";
     cancelSeat(seat.id);
-    socket.emit("clickSeat", "A", seat.id);
+    socket.emit("clickSeat", concertInfo.scheduleId, seat.id);
   };
   useEffect(() => {
-    socket.emit("joinBookingRoom", "A");
     setSeatsCount({ ...serverSeats.counts });
   }, []);
   useEffect(() => {

--- a/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatInfoArea/SeatInfoArea.tsx
@@ -18,6 +18,9 @@ interface SeatInfo {
 }
 const useStyles = makeStyles((theme: Theme) => ({
   seatInfoArea: {
+    position: "fixed",
+    bottom: "30px",
+    width: "414px",
     height: "15rem",
     fontWeight: "bold",
     borderRadius: "0.5rem 0.5rem 0 0",
@@ -109,6 +112,7 @@ export default function SeatInfoArea() {
   const history = useHistory();
   const [seatsCount, setSeatsCount] = useState<any>({});
   const { serverSeats } = useContext(SeatContext);
+
   const GET_ITEMS = gql`
     query ItemDetail($id: ID) {
       itemDetail(itemId: $id) {
@@ -125,8 +129,8 @@ export default function SeatInfoArea() {
 
   const handleClickCancel = (seat: any) => {
     seat.status = "clicked";
-    cancelSeat(seat.id);
-    socket.emit("clickSeat", concertInfo.scheduleId, seat.id);
+    cancelSeat(seat._id);
+    socket.emit("clickSeat", localStorage.getItem("userid"), concertInfo.scheduleId, seat._id);
   };
   useEffect(() => {
     setSeatsCount({ ...serverSeats.counts });
@@ -134,10 +138,14 @@ export default function SeatInfoArea() {
   useEffect(() => {
     setSeatsCount({ ...serverSeats.counts });
   }, [serverSeats.counts]);
+
   if (loading) return <>Loading...</>;
   if (error) return <>`Error! ${error.message}`</>;
-  if (data) {
-  }
+  const { classes: colorInfo } = data.itemDetail;
+  const colors = colorInfo.reduce((acc: any, value: any, idx: any, arr: any) => {
+    acc[value.class] = value.color;
+    return acc;
+  }, {});
 
   return (
     <>
@@ -158,7 +166,7 @@ export default function SeatInfoArea() {
                 return (
                   <ListItem key={idx} className={classes.item}>
                     <Box className={classes.title}>
-                      <Badge component="span" color={data.itemDetail.classes[idx].color}></Badge>
+                      <Badge component="span" color={colors[element]}></Badge>
                       <span>{element}</span>
                     </Box>
                     <Box className={classes.seatCount}>{seatsCount[element]}석</Box>
@@ -174,7 +182,7 @@ export default function SeatInfoArea() {
                   <ListItem key={idx} className={classes.item}>
                     <Box className={classes.seatLoca}>
                       <span>
-                        <Badge component="span" color={element.color}></Badge>
+                        <Badge component="span" color={colors[element.class]}></Badge>
                         <span>{element.name}</span>
                       </span>
                       <CloseIcon

--- a/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
+++ b/client/src/components/SeatSelectionBox/SeatSelectionArea/SeatSelectionArea.tsx
@@ -151,7 +151,7 @@ export default function SeatSelectionArea() {
         },
         {},
       );
-      console.log(serverSeats.seats)
+      console.log(serverSeats.seats);
       console.log(serverData);
       componentSeats = componentSeats.map((seat: SeatInfo) => {
         if (serverData[seat._id]) {

--- a/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
+++ b/client/src/components/common/EmptySeatsCount/EmptySeatsCount.tsx
@@ -2,22 +2,13 @@ import React, { useEffect, useContext, useState } from "react";
 import { Box } from "@material-ui/core";
 import { makeStyles, styled } from "@material-ui/core/styles";
 import { colors } from "../../../styles/variables";
-import useSeats from "../../../hooks/useSeats";
 import { SeatContext } from "../../../stores/SeatStore";
 import { EmptySeatCount } from "../../../types/seatInfo";
 import { socket } from "../../../socket";
-import { useQuery, gql } from "@apollo/client";
 import useConcertInfo from "../../../hooks/useConcertInfo";
-import { Prices } from "../../../types/concertInfo";
-import { useDispatch } from "react-redux";
-import { setPrice } from "../../../modules/concertInfo";
 
 interface styleProps {
   color: string;
-}
-interface SeatInfo {
-  color: string;
-  price: number;
 }
 
 const useStyles = makeStyles(() => ({
@@ -70,54 +61,24 @@ const Badge = styled(Box)((props: styleProps) => ({
   backgroundColor: props.color,
 }));
 
-export default function EmptySeatsCount() {
+export default function EmptySeatsCount({ color, price }: any) {
   const classes = useStyles();
   const [seatsCount, setSeatsCount] = useState<any>({});
   const { serverSeats } = useContext(SeatContext);
   const concertInfo = useConcertInfo();
-  const dispatch = useDispatch();
   const intl = new Intl.NumberFormat("ko-KR");
-  let seatInfo: Prices[] = [];
-
-  const GET_ITEMS = gql`
-    query ItemDetail($id: ID) {
-      itemDetail(itemId: $id) {
-        prices {
-          class
-          price
-        }
-        classes {
-          class
-          color
-        }
-      }
-    }
-  `;
-
-  const { loading, error, data } = useQuery(GET_ITEMS, {
-    variables: { id: concertInfo.id },
-  });
 
   useEffect(() => {
-    socket.emit("joinCountRoom", "A");
+    socket.emit("joinBookingRoom", localStorage.getItem("userid"), concertInfo.scheduleId);
     setSeatsCount({ ...serverSeats.counts });
+    return () => {
+      socket.emit("leaveBookingRoom", concertInfo.scheduleId);
+    };
   }, []);
 
   useEffect(() => {
     setSeatsCount({ ...serverSeats.counts });
   }, [serverSeats.counts]);
-
-  if (loading) return "Loading...";
-  if (error) return `Error! ${error.message}`;
-  if (data) {
-    seatInfo = data.itemDetail.classes.map((value: any, index: number) => {
-      return {
-        class: value.class,
-        color: value.color,
-        price: data.itemDetail.prices[index].price,
-      };
-    });
-  }
 
   return (
     <>
@@ -128,11 +89,11 @@ export default function EmptySeatsCount() {
               return (
                 <tr key={idx} className={classes.item}>
                   <td className={classes.title}>
-                    <Badge component="span" color={seatInfo[idx].color}></Badge>
+                    <Badge component="span" color={color[element]}></Badge>
                     <span>{element}</span>
                   </td>
                   <td className={classes.seatCount}>잔여 {seatsCount[element]}석</td>
-                  <td className={classes.price}>{intl.format(seatInfo[idx].price)}원</td>
+                  <td className={classes.price}>{intl.format(price[element])}원</td>
                 </tr>
               );
             })}

--- a/client/src/components/common/StepButton/StepButton.tsx
+++ b/client/src/components/common/StepButton/StepButton.tsx
@@ -3,6 +3,7 @@ import { Box, Button } from "@material-ui/core";
 import { makeStyles, Theme } from "@material-ui/core/styles";
 import { colors } from "../../../styles/variables";
 import { useHistory } from "react-router-dom";
+import useSeats from "../../../hooks/useSeats";
 import { socket } from "../../../socket";
 
 interface Props {
@@ -43,6 +44,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export default function StepButton({ link, next, click }: Props) {
   const history = useHistory();
   const classes = useStyles();
+  const seats = useSeats().selectedSeat;
 
   const handleClickPre = () => {
     history.goBack();
@@ -67,14 +69,26 @@ export default function StepButton({ link, next, click }: Props) {
       >
         이전단계
       </Button>
-      <Button
-        size="large"
-        variant="contained"
-        onClick={handleClickNext}
-        className={classes.nextBtn}
-      >
-        {next}
-      </Button>
+      {seats.length === 0 ? (
+        <Button
+          size="large"
+          variant="contained"
+          onClick={handleClickNext}
+          className={classes.nextBtn}
+          disabled
+        >
+          {next}
+        </Button>
+      ) : (
+        <Button
+          size="large"
+          variant="contained"
+          onClick={handleClickNext}
+          className={classes.nextBtn}
+        >
+          {next}
+        </Button>
+      )}
     </Box>
   );
 }

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -4,3 +4,4 @@ export { default as ContentsArea } from "./ContentsArea/ContentsArea";
 export { default as ConcertDetails } from "./ConcertDetails/ConcertDetails";
 export { default as LoginArea } from "./LoginArea/LoginArea";
 export { default as PaymentSelectInfo } from "./PaymentSelectInfo/PaymentSelectInfo";
+export { default as MyPageArea } from "./MyPageArea/MyPageArea";

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as ConcertDetails } from "./ConcertDetails/ConcertDetails";
 export { default as LoginArea } from "./LoginArea/LoginArea";
 export { default as PaymentSelectInfo } from "./PaymentSelectInfo/PaymentSelectInfo";
 export { default as MyPageArea } from "./MyPageArea/MyPageArea";
+export { default as BookingCancelArea } from "./BookingCancelArea/BookingCancelArea";

--- a/client/src/modules/concertInfo.ts
+++ b/client/src/modules/concertInfo.ts
@@ -1,8 +1,6 @@
-import { Prices } from "../types/concertInfo";
-
 const CHANGE_SELECTED_CONCERT = "concertInfo/CHANGE_SELECTED_CONCERT" as const;
 const SELECT_SCHEDULE = "concertInfo/SELECT_SCHEDULE" as const;
-const SET_PRICE = "concertInfo/SET_PRICE" as const;
+const SET_CLASS_INFO = "concertInfo/SET_CLASS_INFO" as const;
 
 export const changeSelectedConcert = (id: string) => ({
   type: CHANGE_SELECTED_CONCERT,
@@ -14,9 +12,9 @@ export const selectSchedule = (id: string, dateDetail: string) => ({
   payload: { id, dateDetail },
 });
 
-export const setPrice = (prices: Prices[]) => ({
-  type: SET_PRICE,
-  payload: prices,
+export const setClassInfo = (prices: Object, colors: Object) => ({
+  type: SET_CLASS_INFO,
+  payload: { prices, colors },
 });
 
 export interface ConcertInfo {
@@ -24,7 +22,8 @@ export interface ConcertInfo {
   name: string;
   scheduleId?: string;
   dateDetail: string;
-  price?: Prices[];
+  prices: any;
+  colors?: any;
   startDate?: string;
   endDate?: string;
   runningTime?: string;
@@ -34,7 +33,7 @@ export interface ConcertInfo {
 type ConcertInfoAction =
   | ReturnType<typeof changeSelectedConcert>
   | ReturnType<typeof selectSchedule>
-  | ReturnType<typeof setPrice>;
+  | ReturnType<typeof setClassInfo>;
 
 type ConcertInfoState = ConcertInfo;
 
@@ -43,7 +42,8 @@ const initialState: ConcertInfoState = {
   name: "",
   scheduleId: undefined,
   dateDetail: "",
-  price: undefined,
+  prices: {},
+  colors: undefined,
   startDate: undefined,
   endDate: undefined,
   runningTime: "2시간 45분",
@@ -66,10 +66,11 @@ const concertInfoReducer = (
         scheduleId: action.payload.id,
         dateDetail: action.payload.dateDetail,
       };
-    case SET_PRICE:
+    case SET_CLASS_INFO:
       return {
         ...state,
-        price: action.payload,
+        prices: { ...action.payload.prices },
+        colors: { ...action.payload.colors },
       };
     default:
       return state;

--- a/client/src/pages/BookingCancel.tsx
+++ b/client/src/pages/BookingCancel.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { MainHeader, BookingCancelArea } from "../components";
+
+export default function BookingCancel() {
+  return (
+    <>
+      <MainHeader title="예매 취소" />
+    </>
+  );
+}

--- a/client/src/pages/MyPage.tsx
+++ b/client/src/pages/MyPage.tsx
@@ -1,10 +1,11 @@
 import React from "react";
-import { MainHeader } from "../components";
+import { MainHeader, MyPageArea } from "../components";
 
 export default function MyPage() {
   return (
     <>
       <MainHeader title="마이페이지" />
+      <MyPageArea />
     </>
   );
 }

--- a/client/src/pages/Payment.tsx
+++ b/client/src/pages/Payment.tsx
@@ -19,6 +19,9 @@ export default function Payment() {
     } else if (concertInfo.id === "") {
       alert("공연을 선택해주세요.");
       history.replace("/");
+    } else if (concertInfo.dateDetail === "") {
+      alert("회차를 선택해주세요");
+      history.replace("/schedule/" + concertInfo.id);
     }
     return () => {
       dispatch(initSeat());

--- a/client/src/pages/Payment.tsx
+++ b/client/src/pages/Payment.tsx
@@ -2,15 +2,26 @@ import React, { useEffect } from "react";
 import { MainHeader, PaymentSelectInfo } from "../components";
 import { initSeat } from "../modules/seats";
 import { useDispatch } from "react-redux";
+import { useHistory } from "react-router-dom";
 import useSeats from "../hooks/useSeats";
+import useConcertInfo from "../hooks/useConcertInfo";
 
 export default function Payment() {
   const dispatch = useDispatch();
-  const seats = useSeats();
+  const history = useHistory();
+  const seats = useSeats().selectedSeat;
+  const concertInfo = useConcertInfo();
+
   useEffect(() => {
+    if (!localStorage.getItem("userid")) {
+      alert("로그인이 필요합니다.");
+      history.replace("/login");
+    } else if (concertInfo.id === "") {
+      alert("공연을 선택해주세요.");
+      history.replace("/");
+    }
     return () => {
       dispatch(initSeat());
-      console.log(1, seats);
     };
   }, []);
   return (

--- a/client/src/pages/SeatSelection.tsx
+++ b/client/src/pages/SeatSelection.tsx
@@ -8,7 +8,13 @@ export default function SeatSelection() {
   const history = useHistory();
 
   useEffect(() => {
-    if (concertInfo.id === "") history.goBack();
+    if (concertInfo.id === "") {
+      alert("공연을 선택해주세요.");
+      history.replace("/");
+    } else if (!concertInfo.scheduleId) {
+      alert("회차를 선택해주세요.");
+      history.replace("/schedule/" + concertInfo.id);
+    }
   }, []);
   return (
     <>

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -4,3 +4,4 @@ export { default as Payment } from "./Payment";
 export { default as ItemList } from "./ItemList";
 export { default as Login } from "./Login";
 export { default as MyPage } from "./MyPage";
+export { default as BookingCancel } from "./BookingCancel";

--- a/client/src/styles/variables.ts
+++ b/client/src/styles/variables.ts
@@ -13,4 +13,7 @@ export const colors = {
   borderGray2: "#bbb",
   borderLightGray: "#e2e2e2",
   borderLightGray2: "#e7e7e7",
+
+  myPageBlack: "#111",
+  myPagePurple: "#836ad8",
 };


### PR DESCRIPTION
## 구현 내용
- [x] 좌석 색과 좌석 가격을 전역스토어에서 class를 key로 object형식으로 저장하도록 변경
- [x] 회차선택이나 공연선택 하지 않으면 결제, 좌석선택 페이지 들어가지 못하도록 변경
- [x] 마이페이지 구현
- [x] 예매 취소중일 때 접속하는 페이지 생성(현재 이벤트 emit은 하고있지만 동작하지는 않음)
## 해야할 것
- [ ] 결제내역 공연날짜 저장될 때 month에 +1이 되어 저장되는 부분 수정
- [ ] 리팩토링
- [ ] 취소페이지 완성하기
- [x] 마이페이지 새로고침 하지 않으면 방금 예매한 내용은 보여지지 않는 부분 해결하기
- [ ] 곳곳에 숨어있는 버그 해결...
## 마이페이지 스크린샷
![image](https://user-images.githubusercontent.com/37579982/101848059-eef3fd00-3b97-11eb-8e72-438553111531.png)
